### PR TITLE
Get rid of `with` statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# `ruby-ejs` Uploadcare edition
+
+This is our fork with the only change - working completely without `with` statement. 
+
+This means that it can be used in `strict mode`.
+
 EJS (Embedded JavaScript) template compiler for Ruby
 ====================================================
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `ruby-ejs` Uploadcare edition
 
-This is our fork with the only change - working completely without `with` statement. 
+This is our fork with the only change - internal implementation completely without `with` statements. 
 
 This means that it can be used in `strict mode`.
 

--- a/ejs.gemspec
+++ b/ejs.gemspec
@@ -6,7 +6,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "LICENSE", "lib/**/*.rb"]
 
-  s.add_development_dependency "execjs", "~> 0.4"
+  s.add_runtime_dependency "execjs", "~> 0.4"
+  s.add_runtime_dependency "rkelly-remix", "~> 0.0.7"
 
   s.authors = ["Sam Stephenson"]
   s.email = ["sstephenson@gmail.com"]

--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -66,7 +66,7 @@ module EJS
       end
 
       def js_unescape!(source)
-        source.gsub!(JS_UNESCAPE_PATTERN) { |match| JS_UNESCAPES[match[1..-1]] }        
+        source.gsub!(JS_UNESCAPE_PATTERN) { |match| JS_UNESCAPES[match[1..-1]] }
         source
       end
 

--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -39,7 +39,7 @@ module EJS
       replace_interpolation_tags!(source, options)
       replace_evaluation_tags!(source, options)
 
-      source = "function(__scope){var __p=[],print=function(){__p.push.apply(__p,arguments);};" +
+      source = "function(__scope){if(!__scope){__scope = {};};var __p=[],print=function(){__p.push.apply(__p,arguments);};" +
         "__p.push('#{source}'); return __p.join('');}"
 
       inject_scope(source)

--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -96,15 +96,21 @@ module EJS
         # we need to add variable declaration to get valid js code
         ast = parser.parse("var evaluate = #{source}")
 
+        skipVariables = ['arguments']
+
+        ast.pointcut(RKelly::Nodes::VarDeclNode).matches.each do |node|
+          skipVariables.push node.name
+        end
+
         # iterate through used variables and replace it with ones from __context
-        ast.pointcut(RKelly::Nodes::ResolveNode).matches.map! do |node| 
-          if node.value != '__p'
+        ast.pointcut(RKelly::Nodes::ResolveNode).matches.each do |node| 
+          if !skipVariables.include?(node.value)
             node.value = "__context.#{node.value}"
           end
         end
 
         # remove previously added variable declaration and line breaks
-        ast.to_ecma.gsub('var evaluate = ', '').gsub("\n", ' ')
+        source = ast.to_ecma.gsub('var evaluate = ', '').gsub("\n", ' ')
       end
 
       def escape_function

--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -96,6 +96,7 @@ module EJS
         # we need to add variable declaration to get valid js code
         ast = parser.parse("var evaluate = #{source}")
 
+        # collect declarated variables to skip them from modifying
         skipVariables = ['arguments']
 
         ast.pointcut(RKelly::Nodes::VarDeclNode).matches.each do |node|

--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -29,7 +29,7 @@ module EJS
     # template.
     #
     #     EJS.compile("Hello <%= name %>")
-    #     # => "function(__context){...}"
+    #     # => "function(__scope){...}"
     #
     def compile(source, options = {})
       source = source.dup
@@ -39,10 +39,10 @@ module EJS
       replace_interpolation_tags!(source, options)
       replace_evaluation_tags!(source, options)
 
-      source = "function(__context){var __p=[],print=function(){__p.push.apply(__p,arguments);};" +
+      source = "function(__scope){var __p=[],print=function(){__p.push.apply(__p,arguments);};" +
         "__p.push('#{source}'); return __p.join('');}"
 
-      inject_context(source)
+      inject_scope(source)
     end
 
     # Evaluates an EJS template with the given local variables and
@@ -88,7 +88,7 @@ module EJS
         end
       end
 
-      def inject_context(source)
+      def inject_scope(source)
         require 'rkelly'
 
         parser = RKelly::Parser.new
@@ -103,10 +103,10 @@ module EJS
           skipVariables.push node.name
         end
 
-        # iterate through undeclared variables and replace them with ones from __context
+        # iterate through undeclared variables and replace them with ones from __scope
         ast.pointcut(RKelly::Nodes::ResolveNode).matches.each do |node| 
           if !skipVariables.include?(node.value)
-            node.value = "__context.#{node.value}"
+            node.value = "__scope.#{node.value}"
           end
         end
 

--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -42,7 +42,7 @@ module EJS
       source = "function(__context){var __p=[],print=function(){__p.push.apply(__p,arguments);};" +
         "__p.push('#{source}'); return __p.join('');}"
 
-      pass_locals(source)
+      inject_context(source)
     end
 
     # Evaluates an EJS template with the given local variables and
@@ -88,7 +88,7 @@ module EJS
         end
       end
 
-      def pass_locals(source)
+      def inject_context(source)
         require 'rkelly'
 
         parser = RKelly::Parser.new
@@ -103,7 +103,7 @@ module EJS
           skipVariables.push node.name
         end
 
-        # iterate through used variables and replace it with ones from __context
+        # iterate through undeclared variables and replace them with ones from __context
         ast.pointcut(RKelly::Nodes::ResolveNode).matches.each do |node| 
           if !skipVariables.include?(node.value)
             node.value = "__context.#{node.value}"

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -1,19 +1,7 @@
 require "ejs"
 require "test/unit"
 
-FUNCTION_PATTERN = /^function\s*\(.*?\)\s*\{(.*?)\}$/
-
-BRACE_SYNTAX = {
-  :evaluation_pattern    => /\{\{([\s\S]+?)\}\}/,
-  :interpolation_pattern => /\{\{=([\s\S]+?)\}\}/,
-  :escape_pattern        => /\{\{-([\s\S]+?)\}\}/
-}
-
-QUESTION_MARK_SYNTAX = {
-  :evaluation_pattern    => /<\?([\s\S]+?)\?>/,
-  :interpolation_pattern => /<\?=([\s\S]+?)\?>/,
-  :escape_pattern        => /<\?-([\s\S]+?)\?>/
-}
+FUNCTION_PATTERN = /^function\s*\(.*?\)\s*\{(.*?)\};$/
 
 module TestHelper
   def test(name, &block)
@@ -29,172 +17,34 @@ class EJSCompilationTest < Test::Unit::TestCase
     assert_match FUNCTION_PATTERN, result
     assert_no_match(/Hello \<%= name %\>/, result)
   end
-
-  test "compile with custom syntax" do
-    standard_result = EJS.compile("Hello <%= name %>")
-    braced_result   = EJS.compile("Hello {{= name }}", BRACE_SYNTAX)
-
-    assert_match FUNCTION_PATTERN, braced_result
-    assert_equal standard_result, braced_result
-  end
-end
-
-class EJSCustomPatternTest < Test::Unit::TestCase
-  extend TestHelper
-
-  def setup
-    @original_evaluation_pattern = EJS.evaluation_pattern
-    @original_interpolation_pattern = EJS.interpolation_pattern
-    EJS.evaluation_pattern = BRACE_SYNTAX[:evaluation_pattern]
-    EJS.interpolation_pattern = BRACE_SYNTAX[:interpolation_pattern]
-  end
-
-  def teardown
-    EJS.interpolation_pattern = @original_interpolation_pattern
-    EJS.evaluation_pattern = @original_evaluation_pattern
-  end
-
-  test "compile" do
-    result = EJS.compile("Hello {{= name }}")
-    assert_match FUNCTION_PATTERN, result
-    assert_no_match(/Hello \{\{= name \}\}/, result)
-  end
-
-  test "compile with custom syntax" do
-    standard_result = EJS.compile("Hello {{= name }}")
-    question_result = EJS.compile("Hello <?= name ?>", QUESTION_MARK_SYNTAX)
-
-    assert_match FUNCTION_PATTERN, question_result
-    assert_equal standard_result, question_result
-  end
 end
 
 class EJSEvaluationTest < Test::Unit::TestCase
   extend TestHelper
 
-  test "quotes" do
-    template = "<%= thing %> is gettin' on my noives!"
-    assert_equal "This is gettin' on my noives!", EJS.evaluate(template, :thing => "This")
+  test "function calls" do
+    template = "<%= t('foo') %>"
+    assert_equal "bar", EJS.evaluate(template, :t => lambda{ 'bar' })
   end
 
-  test "backslashes" do
-    template = "<%= thing %> is \\ridanculous"
-    assert_equal "This is \\ridanculous", EJS.evaluate(template, :thing => "This")
+  test "simple variable" do
+    template = "<%= name %>"
+    assert_equal "Name", EJS.evaluate(template, :name => 'Name')
   end
 
-  test "backslashes into interpolation" do
-    template = %q{<%= "Hello \"World\"" %>}
-    assert_equal 'Hello "World"', EJS.evaluate(template)
+  test "deep object" do
+    template = "<%= deep.variable %>"
+    assert_equal "Deep.Variable", EJS.evaluate(template, :deep => {:variable => 'Deep.Variable'})
   end
 
-  test "implicit semicolon" do
-    template = "<% var foo = 'bar' %>"
-    assert_equal '', EJS.evaluate(template)
+  test "simple logic" do
+    template = "<%= foo || 'default' %> <%= bar || 'default' %>"
+    assert_equal "default bar", EJS.evaluate(template, :bar => 'bar')
   end
 
-  test "iteration" do
-    template = "<ul><%
-      for (var i = 0; i < people.length; i++) {
-    %><li><%= people[i] %></li><% } %></ul>"
-    result = EJS.evaluate(template, :people => ["Moe", "Larry", "Curly"])
-    assert_equal "<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>", result
+  test "simple if statements" do
+    template = "<% if(crop) { %>DO CROP<% } %>"
+    assert_equal "DO CROP", EJS.evaluate(template, :crop => 1)
   end
 
-  test "without interpolation" do
-    template = "<div><p>Just some text. Hey, I know this is silly but it aids consistency.</p></div>"
-    assert_equal template, EJS.evaluate(template)
-  end
-
-  test "two quotes" do
-    template = "It's its, not it's"
-    assert_equal template, EJS.evaluate(template)
-  end
-
-  test "quote in statement and body" do
-    template = "<%
-      if(foo == 'bar'){
-    %>Statement quotes and 'quotes'.<% } %>"
-    assert_equal "Statement quotes and 'quotes'.", EJS.evaluate(template, :foo => "bar")
-  end
-
-  test "newlines and tabs" do
-    template = "This\n\t\tis: <%= x %>.\n\tok.\nend."
-    assert_equal "This\n\t\tis: that.\n\tok.\nend.", EJS.evaluate(template, :x => "that")
-  end
-
-
-  test "braced iteration" do
-    template = "<ul>{{ for (var i = 0; i < people.length; i++) { }}<li>{{= people[i] }}</li>{{ } }}</ul>"
-    result = EJS.evaluate(template, { :people => ["Moe", "Larry", "Curly"] }, BRACE_SYNTAX)
-    assert_equal "<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>", result
-  end
-
-  test "braced quotes" do
-    template = "It's its, not it's"
-    assert_equal template, EJS.evaluate(template, {}, BRACE_SYNTAX)
-  end
-
-  test "braced quotes in statement and body" do
-    template = "{{ if(foo == 'bar'){ }}Statement quotes and 'quotes'.{{ } }}"
-    assert_equal "Statement quotes and 'quotes'.", EJS.evaluate(template, { :foo => "bar" }, BRACE_SYNTAX)
-  end
-
-
-  test "question-marked iteration" do
-    template = "<ul><? for (var i = 0; i < people.length; i++) { ?><li><?= people[i] ?></li><? } ?></ul>"
-    result = EJS.evaluate(template, { :people => ["Moe", "Larry", "Curly"] }, QUESTION_MARK_SYNTAX)
-    assert_equal "<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>", result
-  end
-
-  test "question-marked quotes" do
-    template = "It's its, not it's"
-    assert_equal template, EJS.evaluate(template, {}, QUESTION_MARK_SYNTAX)
-  end
-
-  test "question-marked quote in statement and body" do
-    template = "<? if(foo == 'bar'){ ?>Statement quotes and 'quotes'.<? } ?>"
-    assert_equal "Statement quotes and 'quotes'.", EJS.evaluate(template, { :foo => "bar" }, QUESTION_MARK_SYNTAX)
-  end
-
-  test "escaping" do
-    template = "<%- foobar %>"
-    assert_equal "&lt;b&gt;Foo Bar&lt;&#x2F;b&gt;", EJS.evaluate(template, { :foobar => "<b>Foo Bar</b>" })
-
-    template = "<%- foobar %>"
-    assert_equal "Foo &amp; Bar", EJS.evaluate(template, { :foobar => "Foo & Bar" })
-
-    template = "<%- foobar %>"
-    assert_equal "&quot;Foo Bar&quot;", EJS.evaluate(template, { :foobar => '"Foo Bar"' })
-
-    template = "<%- foobar %>"
-    assert_equal "&#x27;Foo Bar&#x27;", EJS.evaluate(template, { :foobar => "'Foo Bar'" })
-  end
-
-  test "braced escaping" do
-    template = "{{- foobar }}"
-    assert_equal "&lt;b&gt;Foo Bar&lt;&#x2F;b&gt;", EJS.evaluate(template, { :foobar => "<b>Foo Bar</b>" }, BRACE_SYNTAX)
-
-    template = "{{- foobar }}"
-    assert_equal "Foo &amp; Bar", EJS.evaluate(template, { :foobar => "Foo & Bar" }, BRACE_SYNTAX)
-
-    template = "{{- foobar }}"
-    assert_equal "&quot;Foo Bar&quot;", EJS.evaluate(template, { :foobar => '"Foo Bar"' }, BRACE_SYNTAX)
-
-    template = "{{- foobar }}"
-    assert_equal "&#x27;Foo Bar&#x27;", EJS.evaluate(template, { :foobar => "'Foo Bar'" }, BRACE_SYNTAX)
-  end
-
-  test "question-mark escaping" do
-    template = "<?- foobar ?>"
-    assert_equal "&lt;b&gt;Foo Bar&lt;&#x2F;b&gt;", EJS.evaluate(template, { :foobar => "<b>Foo Bar</b>" }, QUESTION_MARK_SYNTAX)
-
-    template = "<?- foobar ?>"
-    assert_equal "Foo &amp; Bar", EJS.evaluate(template, { :foobar => "Foo & Bar" }, QUESTION_MARK_SYNTAX)
-
-    template = "<?- foobar ?>"
-    assert_equal "&quot;Foo Bar&quot;", EJS.evaluate(template, { :foobar => '"Foo Bar"' }, QUESTION_MARK_SYNTAX)
-
-    template = "<?- foobar ?>"
-    assert_equal "&#x27;Foo Bar&#x27;", EJS.evaluate(template, { :foobar => "'Foo Bar'" }, QUESTION_MARK_SYNTAX)
-  end
 end

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -3,6 +3,18 @@ require "test/unit"
 
 FUNCTION_PATTERN = /^function\s*\(.*?\)\s*\{(.*?)\};$/
 
+BRACE_SYNTAX = {
+  :evaluation_pattern    => /\{\{([\s\S]+?)\}\}/,
+  :interpolation_pattern => /\{\{=([\s\S]+?)\}\}/,
+  :escape_pattern        => /\{\{-([\s\S]+?)\}\}/
+}
+
+QUESTION_MARK_SYNTAX = {
+  :evaluation_pattern    => /<\?([\s\S]+?)\?>/,
+  :interpolation_pattern => /<\?=([\s\S]+?)\?>/,
+  :escape_pattern        => /<\?-([\s\S]+?)\?>/
+}
+
 module TestHelper
   def test(name, &block)
     define_method("test #{name.inspect}", &block)
@@ -17,34 +29,172 @@ class EJSCompilationTest < Test::Unit::TestCase
     assert_match FUNCTION_PATTERN, result
     assert_no_match(/Hello \<%= name %\>/, result)
   end
+
+  test "compile with custom syntax" do
+    standard_result = EJS.compile("Hello <%= name %>")
+    braced_result   = EJS.compile("Hello {{= name }}", BRACE_SYNTAX)
+
+    assert_match FUNCTION_PATTERN, braced_result
+    assert_equal standard_result, braced_result
+  end
+end
+
+class EJSCustomPatternTest < Test::Unit::TestCase
+  extend TestHelper
+
+  def setup
+    @original_evaluation_pattern = EJS.evaluation_pattern
+    @original_interpolation_pattern = EJS.interpolation_pattern
+    EJS.evaluation_pattern = BRACE_SYNTAX[:evaluation_pattern]
+    EJS.interpolation_pattern = BRACE_SYNTAX[:interpolation_pattern]
+  end
+
+  def teardown
+    EJS.interpolation_pattern = @original_interpolation_pattern
+    EJS.evaluation_pattern = @original_evaluation_pattern
+  end
+
+  test "compile" do
+    result = EJS.compile("Hello {{= name }}")
+    assert_match FUNCTION_PATTERN, result
+    assert_no_match(/Hello \{\{= name \}\}/, result)
+  end
+
+  test "compile with custom syntax" do
+    standard_result = EJS.compile("Hello {{= name }}")
+    question_result = EJS.compile("Hello <?= name ?>", QUESTION_MARK_SYNTAX)
+
+    assert_match FUNCTION_PATTERN, question_result
+    assert_equal standard_result, question_result
+  end
 end
 
 class EJSEvaluationTest < Test::Unit::TestCase
   extend TestHelper
 
-  test "function calls" do
-    template = "<%= t('foo') %>"
-    assert_equal "bar", EJS.evaluate(template, :t => lambda{ 'bar' })
+  test "quotes" do
+    template = "<%= thing %> is gettin' on my noives!"
+    assert_equal "This is gettin' on my noives!", EJS.evaluate(template, :thing => "This")
   end
 
-  test "simple variable" do
-    template = "<%= name %>"
-    assert_equal "Name", EJS.evaluate(template, :name => 'Name')
+  test "backslashes" do
+    template = "<%= thing %> is \\ridanculous"
+    assert_equal "This is \\ridanculous", EJS.evaluate(template, :thing => "This")
   end
 
-  test "deep object" do
-    template = "<%= deep.variable %>"
-    assert_equal "Deep.Variable", EJS.evaluate(template, :deep => {:variable => 'Deep.Variable'})
+  test "backslashes into interpolation" do
+    template = %q{<%= "Hello \"World\"" %>}
+    assert_equal 'Hello "World"', EJS.evaluate(template)
   end
 
-  test "simple logic" do
-    template = "<%= foo || 'default' %> <%= bar || 'default' %>"
-    assert_equal "default bar", EJS.evaluate(template, :bar => 'bar')
+  test "implicit semicolon" do
+    template = "<% var foo = 'bar' %>"
+    assert_equal '', EJS.evaluate(template)
   end
 
-  test "simple if statements" do
-    template = "<% if(crop) { %>DO CROP<% } %>"
-    assert_equal "DO CROP", EJS.evaluate(template, :crop => 1)
+  test "iteration" do
+    template = "<ul><%
+      for (var i = 0; i < people.length; i++) {
+    %><li><%= people[i] %></li><% } %></ul>"
+    result = EJS.evaluate(template, :people => ["Moe", "Larry", "Curly"])
+    assert_equal "<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>", result
   end
 
+  test "without interpolation" do
+    template = "<div><p>Just some text. Hey, I know this is silly but it aids consistency.</p></div>"
+    assert_equal template, EJS.evaluate(template)
+  end
+
+  test "two quotes" do
+    template = "It's its, not it's"
+    assert_equal template, EJS.evaluate(template)
+  end
+
+  test "quote in statement and body" do
+    template = "<%
+      if(foo == 'bar'){
+    %>Statement quotes and 'quotes'.<% } %>"
+    assert_equal "Statement quotes and 'quotes'.", EJS.evaluate(template, :foo => "bar")
+  end
+
+  test "newlines and tabs" do
+    template = "This\n\t\tis: <%= x %>.\n\tok.\nend."
+    assert_equal "This\n\t\tis: that.\n\tok.\nend.", EJS.evaluate(template, :x => "that")
+  end
+
+
+  test "braced iteration" do
+    template = "<ul>{{ for (var i = 0; i < people.length; i++) { }}<li>{{= people[i] }}</li>{{ } }}</ul>"
+    result = EJS.evaluate(template, { :people => ["Moe", "Larry", "Curly"] }, BRACE_SYNTAX)
+    assert_equal "<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>", result
+  end
+
+  test "braced quotes" do
+    template = "It's its, not it's"
+    assert_equal template, EJS.evaluate(template, {}, BRACE_SYNTAX)
+  end
+
+  test "braced quotes in statement and body" do
+    template = "{{ if(foo == 'bar'){ }}Statement quotes and 'quotes'.{{ } }}"
+    assert_equal "Statement quotes and 'quotes'.", EJS.evaluate(template, { :foo => "bar" }, BRACE_SYNTAX)
+  end
+
+
+  test "question-marked iteration" do
+    template = "<ul><? for (var i = 0; i < people.length; i++) { ?><li><?= people[i] ?></li><? } ?></ul>"
+    result = EJS.evaluate(template, { :people => ["Moe", "Larry", "Curly"] }, QUESTION_MARK_SYNTAX)
+    assert_equal "<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>", result
+  end
+
+  test "question-marked quotes" do
+    template = "It's its, not it's"
+    assert_equal template, EJS.evaluate(template, {}, QUESTION_MARK_SYNTAX)
+  end
+
+  test "question-marked quote in statement and body" do
+    template = "<? if(foo == 'bar'){ ?>Statement quotes and 'quotes'.<? } ?>"
+    assert_equal "Statement quotes and 'quotes'.", EJS.evaluate(template, { :foo => "bar" }, QUESTION_MARK_SYNTAX)
+  end
+
+  test "escaping" do
+    template = "<%- foobar %>"
+    assert_equal "&lt;b&gt;Foo Bar&lt;&#x2F;b&gt;", EJS.evaluate(template, { :foobar => "<b>Foo Bar</b>" })
+
+    template = "<%- foobar %>"
+    assert_equal "Foo &amp; Bar", EJS.evaluate(template, { :foobar => "Foo & Bar" })
+
+    template = "<%- foobar %>"
+    assert_equal "&quot;Foo Bar&quot;", EJS.evaluate(template, { :foobar => '"Foo Bar"' })
+
+    template = "<%- foobar %>"
+    assert_equal "&#x27;Foo Bar&#x27;", EJS.evaluate(template, { :foobar => "'Foo Bar'" })
+  end
+
+  test "braced escaping" do
+    template = "{{- foobar }}"
+    assert_equal "&lt;b&gt;Foo Bar&lt;&#x2F;b&gt;", EJS.evaluate(template, { :foobar => "<b>Foo Bar</b>" }, BRACE_SYNTAX)
+
+    template = "{{- foobar }}"
+    assert_equal "Foo &amp; Bar", EJS.evaluate(template, { :foobar => "Foo & Bar" }, BRACE_SYNTAX)
+
+    template = "{{- foobar }}"
+    assert_equal "&quot;Foo Bar&quot;", EJS.evaluate(template, { :foobar => '"Foo Bar"' }, BRACE_SYNTAX)
+
+    template = "{{- foobar }}"
+    assert_equal "&#x27;Foo Bar&#x27;", EJS.evaluate(template, { :foobar => "'Foo Bar'" }, BRACE_SYNTAX)
+  end
+
+  test "question-mark escaping" do
+    template = "<?- foobar ?>"
+    assert_equal "&lt;b&gt;Foo Bar&lt;&#x2F;b&gt;", EJS.evaluate(template, { :foobar => "<b>Foo Bar</b>" }, QUESTION_MARK_SYNTAX)
+
+    template = "<?- foobar ?>"
+    assert_equal "Foo &amp; Bar", EJS.evaluate(template, { :foobar => "Foo & Bar" }, QUESTION_MARK_SYNTAX)
+
+    template = "<?- foobar ?>"
+    assert_equal "&quot;Foo Bar&quot;", EJS.evaluate(template, { :foobar => '"Foo Bar"' }, QUESTION_MARK_SYNTAX)
+
+    template = "<?- foobar ?>"
+    assert_equal "&#x27;Foo Bar&#x27;", EJS.evaluate(template, { :foobar => "'Foo Bar'" }, QUESTION_MARK_SYNTAX)
+  end
 end


### PR DESCRIPTION
Old internal implementation:

```javascript
const template = (scope) => {
  with(scope) {
    return foo;
  }
}

template({foo: 'bar'});
```

New one:

```javascript
const template = (scope) => {
   return scope.foo;
}

template({foo: 'bar'});
```

I've used `rkelly-remix` to build AST from template function and prepend undeclared variable usages with the local scope object, i.e. `scope => foo` becomes `scope => scope.foo`. Thus getting rid of `with` statement.

All original tests passed, no behaviour changes.